### PR TITLE
Fix timing issues, refactorings.

### DIFF
--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -945,6 +945,9 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
     private class UsbReceiver extends BroadcastReceiver {
         @Override
         public void onReceive(Context context, Intent intent) {
+            // TODO move this somewhere else ... wherever it belongs
+            // realm might be closed ... sometimes occurs when USB is disconnected and replugged ...
+            if (mRealm.isClosed()) mRealm = Realm.getDefaultInstance();
             String action = intent.getAction();
             if (MedtronicCnlIntentService.Constants.ACTION_USB_PERMISSION.equals(action)) {
                 boolean permissionGranted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false);

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -109,7 +109,6 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
      * @param pumpStatusData
      * @return timestamp
      */
-    // TODO remove code duplication; this method and MdtCnlIntentService.scheduleNextPoll
     public static long getNextPoll(PumpStatusEvent pumpStatusData) {
         long nextPoll = pumpStatusData.getSgvDate().getTime() + pumpStatusData.getPumpTimeOffset(),
                 now = System.currentTimeMillis(),

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -70,7 +70,6 @@ import info.nightscout.android.USB.UsbHidDriver;
 import info.nightscout.android.eula.Eula;
 import info.nightscout.android.eula.Eula.OnEulaAgreedTo;
 import info.nightscout.android.medtronic.service.MedtronicCnlAlarmManager;
-import info.nightscout.android.medtronic.service.MedtronicCnlAlarmReceiver;
 import info.nightscout.android.medtronic.service.MedtronicCnlIntentService;
 import info.nightscout.android.model.medtronicNg.PumpInfo;
 import info.nightscout.android.model.medtronicNg.PumpStatusEvent;
@@ -93,7 +92,6 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
 
     private int chartZoom = 3;
     private boolean hasZoomedChart = false;
-    private NumberFormat sgvFormatter;
 
     private boolean mEnableCgmService = true;
     private SharedPreferences prefs = null;
@@ -104,7 +102,6 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
     private Runnable mUiRefreshRunnable = new RefreshDisplayRunnable();
     private Realm mRealm;
     private StatusMessageReceiver statusMessageReceiver = new StatusMessageReceiver();
-    private MedtronicCnlAlarmReceiver medtronicCnlAlarmReceiver = new MedtronicCnlAlarmReceiver();
 
     /**
      * calculate the next poll timestamp based on last svg event
@@ -167,15 +164,6 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
         chartZoom = Integer.parseInt(prefs.getString("chartZoom", "3"));
         configurationStore.setMmolxl(prefs.getBoolean("mmolxl", false));
         configurationStore.setMmolxlDecimals(prefs.getBoolean("mmolDecimals", false));
-
-        if (configurationStore.isMmolxl()) {
-            if (configurationStore.isMmolxlDecimals())
-                sgvFormatter = new DecimalFormat("0.00");
-            else
-                sgvFormatter = new DecimalFormat("0.0");
-        } else {
-            sgvFormatter = new DecimalFormat("0");
-        }
 
         // Disable battery optimization to avoid missing values on 6.0+
         // taken from https://github.com/NightscoutFoundation/xDrip/blob/master/app/src/main/java/com/eveningoutpost/dexdrip/Home.java#L277L298
@@ -560,14 +548,6 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
         } else if (key.equals("mmolxl") || key.equals("mmolDecimals")) {
             configurationStore.setMmolxl(sharedPreferences.getBoolean("mmolxl", false));
             configurationStore.setMmolxlDecimals(sharedPreferences.getBoolean("mmolDecimals", false));
-            if (configurationStore.isMmolxl()) {
-                if (configurationStore.isMmolxlDecimals())
-                    sgvFormatter = new DecimalFormat("0.00");
-                else
-                    sgvFormatter = new DecimalFormat("0.0");
-            } else {
-                sgvFormatter = new DecimalFormat("0");
-            }
             refreshDisplay();
         } else if (key.equals("pollInterval")) {
             configurationStore.setPollInterval(Long.parseLong(sharedPreferences.getString("pollInterval",

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -112,6 +112,7 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
      * @param pumpStatusData
      * @return timestamp
      */
+    // TODO remove code duplication; this method and MdtCnlIntentService.scheduleNextPoll
     public static long getNextPoll(PumpStatusEvent pumpStatusData) {
         long nextPoll = pumpStatusData.getSgvDate().getTime() + pumpStatusData.getPumpTimeOffset(),
                 now = System.currentTimeMillis(),

--- a/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlAlarmManager.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlAlarmManager.java
@@ -16,11 +16,10 @@ import info.nightscout.android.utils.ConfigurationStore;
  */
 public class MedtronicCnlAlarmManager {
     private static final String TAG = MedtronicCnlAlarmManager.class.getSimpleName();
-    private static final int ALARM_ID = 102; // Alarm id
+    private static final int ALARM_ID = 102;
 
     private static PendingIntent pendingIntent = null;
     private static AlarmManager alarmManager = null;
-    private static long nextAlarm = Long.MAX_VALUE;
 
     public static void setContext(Context context) {
         cancelAlarm();
@@ -28,11 +27,6 @@ public class MedtronicCnlAlarmManager {
         alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         Intent intent = new Intent(context, MedtronicCnlAlarmReceiver.class);
         pendingIntent = PendingIntent.getBroadcast(context, ALARM_ID, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-    }
-
-    // Setting the alarm in 15 seconds from now
-    public static void setAlarm() {
-        setAlarm(System.currentTimeMillis());
     }
 
     /**
@@ -44,7 +38,7 @@ public class MedtronicCnlAlarmManager {
         setAlarm(System.currentTimeMillis() + inFuture);
     }
 
-    // Setting the alarm to call onRecieve
+    // Setting the alarm to call onReceive
     public static void setAlarm(long millis) {
         if (alarmManager == null || pendingIntent == null)
             return;
@@ -56,21 +50,14 @@ public class MedtronicCnlAlarmManager {
         if (millis < now)
             millis = now;
 
-        // only accept alarm nearer than the last one
-        //if (nextAlarm < millis && nextAlarm > now) {
-        //    return;
-        //}
-
         cancelAlarm();
-
-        nextAlarm = millis;
 
         Log.d(TAG, "Alarm set to fire at " + new Date(millis));
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             alarmManager.setAlarmClock(new AlarmManager.AlarmClockInfo(millis, null), pendingIntent);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             // Android 5.0.0 + 5.0.1 (e.g. Galaxy S4) has a bug.
-            // Alarms are not exact. Fixed in 5.0.2 oder CM12
+            // Alarms are not exact. Fixed in 5.0.2 and CM12
             alarmManager.setExact(AlarmManager.RTC_WAKEUP, millis, pendingIntent);
         } else {
             alarmManager.set(AlarmManager.RTC_WAKEUP, millis, pendingIntent);

--- a/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
@@ -108,7 +108,7 @@ public class MedtronicCnlIntentService extends IntentService {
 
             long timePollStarted = System.currentTimeMillis(),
                     timePollExpected = timePollStarted,
-                    timeLastGoodSGV = dataStore.getLastPumpStatus().getEventDate().getTime();
+                    timeLastGoodSGV = dataStore.getLastPumpStatus().getSgvDate().getTime();
 
             short pumpBatteryLevel = dataStore.getLastPumpStatus().getBatteryPercentage();
 

--- a/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
@@ -39,6 +39,7 @@ import info.nightscout.android.utils.ConfigurationStore;
 import info.nightscout.android.utils.DataStore;
 import info.nightscout.android.xdrip_plus.XDripPlusUploadReceiver;
 import io.realm.Realm;
+import io.realm.RealmResults;
 
 public class MedtronicCnlIntentService extends IntentService {
     public final static int USB_VID = 0x1a79;
@@ -245,15 +246,12 @@ public class MedtronicCnlIntentService extends IntentService {
                             sendStatus("Pump sent old SGV event, re-polling...");
                         }
 
-                        //MainActivity.timeLastGoodSGV =  pumpRecord.getEventDate().getTime(); // track last good sgv event time
-                        //MainActivity.pumpBattery =  pumpRecord.getBatteryPercentage(); // track pump battery
-                        timeLastGoodSGV = pumpRecord.getEventDate().getTime();
                         dataStore.clearUnavailableSGVCount(); // reset unavailable sgv count
 
                         // Check that the record doesn't already exist before committing
                         RealmResults<PumpStatusEvent> checkExistingRecords = activePump.getPumpHistory()
                                 .where()
-                                .equalTo("eventDate", pumpRecord.getEventDate())    // >>>>>>> check as event date may not = exact pump event date due to it being stored with offset added this could lead to dup events due to slight variability in time offset
+                                .equalTo("sgvDate", pumpRecord.getSgvDate())
                                 .equalTo("sgv", pumpRecord.getSgv())
                                 .findAll();
 

--- a/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
@@ -229,7 +229,7 @@ public class MedtronicCnlIntentService extends IntentService {
                         if (pumpOffset > 0) {
                             offsetSign = "+";
                         }
-                        sendStatus("SGV: " + MainActivity.strFormatSGV(pumpRecord.getSgv()) + "  At: " + df.format(pumpRecord.getEventDate().getTime()) + "  Pump: " + offsetSign + (pumpOffset / 1000L) + "sec");  //note: event time is currently stored with offset
+                        sendStatus("SGV: " + MainActivity.strFormatSGV(pumpRecord.getSgv()) + "  At: " + df.format(pumpRecord.getSgvDate().getTime()) + "  Pump: " + offsetSign + (pumpOffset / 1000L) + "sec");  //note: event time is currently stored with offset
 
                         // Check if pump sent old event when new expected
                         if (pumpRecord != null &&

--- a/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
@@ -39,7 +39,6 @@ import info.nightscout.android.utils.ConfigurationStore;
 import info.nightscout.android.utils.DataStore;
 import info.nightscout.android.xdrip_plus.XDripPlusUploadReceiver;
 import io.realm.Realm;
-import io.realm.RealmResults;
 
 public class MedtronicCnlIntentService extends IntentService {
     public final static int USB_VID = 0x1a79;

--- a/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
@@ -311,10 +311,8 @@ public class MedtronicCnlIntentService extends IntentService {
                     }
                     realm.close();
                 }
-                // TODO - set status if offline or Nightscout not reachable
-                sendToXDrip();
-                uploadToNightscout();
 
+                uploadPollResults();
                 scheduleNextPoll(timePollStarted, timeLastGoodSGV, pollInterval, df);
             }
         } finally {
@@ -384,6 +382,12 @@ public class MedtronicCnlIntentService extends IntentService {
             alarm.setExact(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
         } else
             alarm.set(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
+    }
+
+    private void uploadPollResults() {
+        // TODO - set status if offline or Nightscout not reachable
+        sendToXDrip();
+        uploadToNightscout();
     }
 
     private void sendToXDrip() {

--- a/app/src/main/java/info/nightscout/android/upload/nightscout/serializer/EntriesSerializer.java
+++ b/app/src/main/java/info/nightscout/android/upload/nightscout/serializer/EntriesSerializer.java
@@ -81,7 +81,7 @@ public class EntriesSerializer implements JsonSerializer<PumpStatusEvent> {
         jsonObject.addProperty("device", src.getDeviceName());
         jsonObject.addProperty("type", "sgv");
         jsonObject.addProperty("date", src.getSgvDate().getTime());
-        jsonObject.addProperty("dateString", String.valueOf(src.getEventDate()));
+        jsonObject.addProperty("dateString", String.valueOf(src.getSgvDate()));
 
         return jsonObject;
     }

--- a/app/src/main/java/info/nightscout/android/upload/nightscout/serializer/EntriesSerializer.java
+++ b/app/src/main/java/info/nightscout/android/upload/nightscout/serializer/EntriesSerializer.java
@@ -71,6 +71,8 @@ public class EntriesSerializer implements JsonSerializer<PumpStatusEvent> {
         }
     }
 
+    // TODO currentnly unused, see info.nightscout.android.xdrip_plus.XDripPlusUploadIntentService.addSgvEntry()
+    // TODO also, proper method name
     @Override
     public JsonElement serialize(PumpStatusEvent src, Type typeOfSrc, JsonSerializationContext context) {
         final JsonObject jsonObject = new JsonObject();
@@ -78,7 +80,7 @@ public class EntriesSerializer implements JsonSerializer<PumpStatusEvent> {
         jsonObject.addProperty("direction", getDirectionString(src.getCgmTrend()));
         jsonObject.addProperty("device", src.getDeviceName());
         jsonObject.addProperty("type", "sgv");
-        jsonObject.addProperty("date", src.getEventDate().getTime());
+        jsonObject.addProperty("date", src.getSgvDate().getTime());
         jsonObject.addProperty("dateString", String.valueOf(src.getEventDate()));
 
         return jsonObject;

--- a/app/src/main/java/info/nightscout/android/utils/DataStore.java
+++ b/app/src/main/java/info/nightscout/android/utils/DataStore.java
@@ -26,6 +26,7 @@ public class DataStore {
 
             // set some initial dummy values
             PumpStatusEvent dummyStatus = new PumpStatusEvent();
+            dummyStatus.setSgvDate(new Date());
 
             // bypass setter to avoid dealing with a real Realm object
             instance.lastPumpStatus = dummyStatus;

--- a/app/src/main/java/info/nightscout/android/xdrip_plus/XDripPlusUploadIntentService.java
+++ b/app/src/main/java/info/nightscout/android/xdrip_plus/XDripPlusUploadIntentService.java
@@ -145,8 +145,8 @@ public class XDripPlusUploadIntentService extends IntentService {
         json.put("direction", EntriesSerializer.getDirectionString(pumpRecord.getCgmTrend()));
         json.put("device", pumpRecord.getDeviceName());
         json.put("type", "sgv");
-        json.put("date", pumpRecord.getEventDate().getTime());
-        json.put("dateString", pumpRecord.getEventDate());
+        json.put("date", pumpRecord.getSgvDate().getTime());
+        json.put("dateString", pumpRecord.getSgvDate());
 
         entriesArray.put(json);
     }


### PR DESCRIPTION
master/dev caused comms issues (-- on pump display), so I tried the _devel-basal-rates_ branch, which had weird timings (1-2 minutes _before_ CNL read SGVs, reading again after 2-3 minutes). Found the issue to be the use of _PumpStatusEvent.getEventDate()_ when _getSgvDate()_ was needed (the Bugfix: commits). The other commits are refactorings and cleanups I did while reading and trying to understand the code. Works very well for me so far, properly timed readings, proper dates send out to xDrip, NS. Haven't tested timings with low battery or the "increase polling when pump is away".
If desired, I can split up the PR into smaller junks (e.g. bugfix only and refactorings).