### PR TITLE
Samsung Galaxy S4 specific hack to fix the alarm timings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "info.nightscout.android"
+        applicationId "info.nightscout.medtronic600seriesuploader.alarm"
         minSdkVersion 14
         targetSdkVersion 25
         versionName generateVersionName()

--- a/app/src/main/java/info/nightscout/android/UploaderApplication.java
+++ b/app/src/main/java/info/nightscout/android/UploaderApplication.java
@@ -12,6 +12,8 @@ import io.fabric.sdk.android.Fabric;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
 import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
+import com.mikepenz.iconics.Iconics;
+import com.mikepenz.ionicons_typeface_library.Ionicons;
 
 /**
  * Created by lgoedhart on 9/06/2016.
@@ -25,6 +27,8 @@ public class UploaderApplication extends Application {
                 .setFontAttrId(R.attr.fontPath)
                 .build()
         );
+        Iconics.init(getApplicationContext());
+        Iconics.registerFont(new Ionicons());
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
 


### PR DESCRIPTION
Changed applicationId to "info.nightscout.medtronic600seriesuploader.alarm". Having ".alarm" in the applicationId is a Samsung specific hack, that disables Samsun's battery saving mode which makes the alarms to trigger at unspecified times.

When applicationId differs from package name, the Ionicons font has to be explicitly registered.

This is only a hack and maybe a proper fix for this would be stop using alarms completely. But that would require more drastic changes. I leave it up to others to decide if it makes to have this device specific hack as part of master branch. I do not know which Samsung devices are plagued by this. I have tested only with Samsung Galaxy S4.

**Be aware that the downside of changing the applicationId is that the application will be treated as a completely new app in Android. Affects updates...**

