### PR TITLE
Fix: profile basal index out of range error

### DIFF
--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -544,6 +544,10 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
                 dataStore.setSysPollOldSgvRetry(Long.parseLong(sharedPreferences.getString("sysPollOldSgvRetry", "90000")));
                 dataStore.setSysEnableWait500ms(sharedPreferences.getBoolean("sysEnableWait500ms", false));
 
+                // debug
+                dataStore.setDbgEnableExtendedErrors(sharedPreferences.getBoolean("dbgEnableExtendedErrors", false));
+                dataStore.setDbgEnableUploadErrors(sharedPreferences.getBoolean("dbgEnableUploadErrors", true));
+
                 // nightscout
                 dataStore.setNsEnableTreatments(sharedPreferences.getBoolean("nsEnableTreatments", true));
                 dataStore.setNsEnableHistorySync(sharedPreferences.getBoolean("nsEnableHistorySync", false));
@@ -555,8 +559,8 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
                 dataStore.setNsEnableBatteryChange(sharedPreferences.getBoolean("nsEnableBatteryChange", true));
                 dataStore.setNsEnableLifetimes(sharedPreferences.getBoolean("nsEnableLifetimes", false));
                 dataStore.setNsEnableProfileUpload(sharedPreferences.getBoolean("nsEnableProfileUpload", true));
-                dataStore.setNsEnableProfileSingle(sharedPreferences.getBoolean("nsEnableProfileSingle", false));
-                dataStore.setNsEnableProfileOffset(sharedPreferences.getBoolean("nsEnableProfileOffset", false));
+                dataStore.setNsEnableProfileSingle(sharedPreferences.getBoolean("nsEnableProfileSingle", true));
+                dataStore.setNsEnableProfileOffset(sharedPreferences.getBoolean("nsEnableProfileOffset", true));
                 dataStore.setNsProfileDefault(Integer.parseInt(sharedPreferences.getString("nsProfileDefault", "1")));
                 dataStore.setNsActiveInsulinTime(Float.parseFloat(sharedPreferences.getString("nsActiveInsulinTime", "3")));
                 dataStore.setNsEnablePatternChange(sharedPreferences.getBoolean("nsEnablePatternChange", true));

--- a/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlReader.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlReader.java
@@ -266,6 +266,8 @@ public class MedtronicCnlReader {
             basalPatterns.write(response.getBasalPattern());
         }
 
+        Log.d(TAG, "Basal Pattern x8 data size: " + basalPatterns.size());
+
         Log.d(TAG, "Finished getBasalPatterns");
         return basalPatterns.toByteArray();
     }

--- a/app/src/main/java/info/nightscout/android/medtronic/PumpHistoryHandler.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/PumpHistoryHandler.java
@@ -414,7 +414,8 @@ public class PumpHistoryHandler {
             Date[] range = cnlReader.getHistory(start, end, historyType);
 
             Log.d(TAG, historyTAG + "received  " + (range[0] == null ? "null" : dateFormatter.format(range[0])) + " - " + (range[1] == null ? "null" : dateFormatter.format(range[1])));
-            userLogMessage(historyTAG + "received \n      " + (range[0] == null ? "null" : dateFormatter.format(range[0])) + " - " + (range[1] == null ? "null" : dateFormatter.format(range[1])));
+            if (dataStore.isDbgEnableExtendedErrors())
+                userLogMessage(historyTAG + "received \n      " + (range[0] == null ? "null" : dateFormatter.format(range[0])) + " - " + (range[1] == null ? "null" : dateFormatter.format(range[1])));
 
             final Date pulledFrom = range[0];
             //final Date pulledTo = range[1];

--- a/app/src/main/java/info/nightscout/android/medtronic/message/BolusWizardCarbRatiosResponseMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/BolusWizardCarbRatiosResponseMessage.java
@@ -30,7 +30,7 @@ public class BolusWizardCarbRatiosResponseMessage extends MedtronicSendMessageRe
             throw new UnexpectedMessageException("Invalid message received for BolusWizardCarbRatios");
         }
 
-        carbRatios = Arrays.copyOfRange(payload, 5, payload.length - 2);
+        carbRatios = Arrays.copyOfRange(payload, 5, payload.length);
     }
 
     public byte[] getCarbRatios() {

--- a/app/src/main/java/info/nightscout/android/medtronic/message/BolusWizardSensitivityResponseMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/BolusWizardSensitivityResponseMessage.java
@@ -29,7 +29,7 @@ public class BolusWizardSensitivityResponseMessage extends MedtronicSendMessageR
             throw new UnexpectedMessageException("Invalid message received for BolusWizardSensitivity");
         }
 
-        sensitivity = Arrays.copyOfRange(payload, 5, payload.length - 2);
+        sensitivity = Arrays.copyOfRange(payload, 5, payload.length);
     }
 
     public byte[] getSensitivity() {

--- a/app/src/main/java/info/nightscout/android/medtronic/message/BolusWizardTargetsResponseMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/BolusWizardTargetsResponseMessage.java
@@ -29,7 +29,7 @@ public class BolusWizardTargetsResponseMessage extends MedtronicSendMessageRespo
             throw new UnexpectedMessageException("Invalid message received for BolusWizardTargets");
         }
 
-        targets = Arrays.copyOfRange(payload, 5 ,payload.length - 2);
+        targets = Arrays.copyOfRange(payload, 5 ,payload.length);
     }
 
     public byte[] getTargets() {

--- a/app/src/main/java/info/nightscout/android/medtronic/message/CloseConnectionRequestMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/CloseConnectionRequestMessage.java
@@ -21,7 +21,7 @@ public class CloseConnectionRequestMessage extends ContourNextLinkBinaryRequestM
     @Override
     public CloseConnectionResponseMessage send(UsbHidDriver mDevice, int millis) throws IOException, TimeoutException, ChecksumException, EncryptionException, UnexpectedMessageException {
 
-        clearMessage(mDevice, PRESEND_CLEAR_TIMEOUT_MS);
+        clearMessage(mDevice, CLEAR_TIMEOUT_MS);
 
         sendMessage(mDevice);
         if (millis > 0) {

--- a/app/src/main/java/info/nightscout/android/medtronic/message/ContourNextLinkMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/ContourNextLinkMessage.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 
 import javax.crypto.Cipher;
@@ -30,7 +31,7 @@ import static info.nightscout.android.utils.ToolKit.read16BEtoUInt;
 public abstract class ContourNextLinkMessage {
     private static final String TAG = ContourNextLinkMessage.class.getSimpleName();
 
-    public static final int CLEAR_TIMEOUT_MS = 500;
+    public static final int CLEAR_TIMEOUT_MS = 1000; // note: 2000ms was used for v5.1
     public static final int ERROR_CLEAR_TIMEOUT_MS = 2000;
     public static final int PRESEND_CLEAR_TIMEOUT_MS = 100;
 
@@ -406,7 +407,8 @@ public abstract class ContourNextLinkMessage {
             }
         }
 
-        return (decrypted != null ? decrypted : payload);
+        // when returning non-multipacket decrypted data we need to trim the 2 byte checksum
+        return (decrypted != null ? Arrays.copyOfRange(decrypted, 0, decrypted.length - 2) : payload);
     }
 
     private class MultipacketSession {

--- a/app/src/main/java/info/nightscout/android/medtronic/message/PumpBasalPatternResponseMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/PumpBasalPatternResponseMessage.java
@@ -29,7 +29,7 @@ public class PumpBasalPatternResponseMessage extends MedtronicSendMessageRespons
             throw new UnexpectedMessageException("Invalid message received for PumpBasalPattern");
         }
 
-        basalPattern = Arrays.copyOfRange(payload, 3, payload.length - 2);
+        basalPattern = Arrays.copyOfRange(payload, 3, payload.length);
     }
 
     public byte[] getBasalPattern() {
@@ -40,6 +40,8 @@ public class PumpBasalPatternResponseMessage extends MedtronicSendMessageRespons
         int index = 0;
         double rate;
         int time;
+
+        Log.d(TAG, "Pattern data size: " + basalPattern.length);
 
         int number = read8toUInt(basalPattern, index++);
         int items = read8toUInt(basalPattern, index++);

--- a/app/src/main/java/info/nightscout/android/model/medtronicNg/PumpHistoryBasal.java
+++ b/app/src/main/java/info/nightscout/android/model/medtronicNg/PumpHistoryBasal.java
@@ -77,14 +77,14 @@ public class PumpHistoryBasal extends RealmObject implements PumpHistoryInterfac
 
             if (suspend) {
                 treatment.setCreated_at(programmedDate);
-                treatment.setDuration(duration);
+                treatment.setDuration((float) duration);
                 treatment.setAbsolute((float) 0);
                 notes = PumpHistoryParser.TextEN.NS_SUSPEND.getText() + ": " +
                         PumpHistoryParser.TextEN.valueOf(PumpHistoryParser.SUSPEND_REASON.convert(suspendReason).name()).getText();
 
             } else if (resume) {
                 treatment.setCreated_at(programmedDate);
-                treatment.setDuration(0);
+                treatment.setDuration((float) 0);
                 notes = PumpHistoryParser.TextEN.NS_RESUME.getText() + ": " +
                         PumpHistoryParser.TextEN.valueOf(PumpHistoryParser.RESUME_REASON.convert(resumeReason).name()).getText();
 
@@ -94,7 +94,7 @@ public class PumpHistoryBasal extends RealmObject implements PumpHistoryInterfac
                 notes += "Temp Basal:";
 
                 if (PumpHistoryParser.TEMP_BASAL_TYPE.PERCENT.equals(type)) {
-                    treatment.setPercent(percentageOfRate - 100);
+                    treatment.setPercent((float) (percentageOfRate - 100));
                     notes += " " + percentageOfRate + "%";
                 } else {
                     treatment.setAbsolute((float) rate);
@@ -107,10 +107,10 @@ public class PumpHistoryBasal extends RealmObject implements PumpHistoryInterfac
                     notes += " [" + PumpHistoryParser.TextEN.valueOf(PumpHistoryParser.TEMP_BASAL_PRESET.convert(preset).name()).getText() + "]";
 
                 if (!canceled) {
-                    treatment.setDuration(duration);
+                    treatment.setDuration((float) duration);
                 } else {
                     int minutes = (int) Math.ceil((completedRTC - programmedRTC) / 60);
-                    treatment.setDuration(minutes);
+                    treatment.setDuration((float) minutes);
                     notes += " * canceled, duration " + minutes + " minutes";
                     uploadItem.update();
                 }

--- a/app/src/main/java/info/nightscout/android/model/medtronicNg/PumpHistoryBolus.java
+++ b/app/src/main/java/info/nightscout/android/model/medtronicNg/PumpHistoryBolus.java
@@ -114,22 +114,22 @@ public class PumpHistoryBolus extends RealmObject implements PumpHistoryInterfac
             } else if (PumpHistoryParser.BOLUS_TYPE.SQUARE_WAVE.equals(bolusType)) {
                 treatment.setEventType("Combo Bolus");
                 treatment.setEnteredinsulin(String.valueOf(squareProgrammedAmount));
-                treatment.setDuration(squareProgrammedDuration);
+                treatment.setDuration((float) squareProgrammedDuration);
                 treatment.setSplitNow("0");
                 treatment.setSplitExt("100");
-                treatment.setRelative(2);
+                treatment.setRelative((float) 2);
                 notes += "Square Bolus: " + squareProgrammedAmount + "U, duration " + squareProgrammedDuration + " minutes";
 
             } else if (PumpHistoryParser.BOLUS_TYPE.DUAL_WAVE.equals(bolusType)) {
                 treatment.setEventType("Combo Bolus");
                 treatment.setEnteredinsulin(String.valueOf(normalProgrammedAmount + squareProgrammedAmount));
-                treatment.setDuration(squareProgrammedDuration);
+                treatment.setDuration((float) squareProgrammedDuration);
                 treatment.setInsulin((float) normalProgrammedAmount);
                 int splitNow = (int) (normalProgrammedAmount * (100 / (normalProgrammedAmount + squareProgrammedAmount)));
                 int splitExt = 100 - splitNow;
                 treatment.setSplitNow(String.valueOf(splitNow));
                 treatment.setSplitExt(String.valueOf(splitExt));
-                treatment.setRelative(2);
+                treatment.setRelative((float) 2);
                 notes += "Dual Bolus: normal " + normalProgrammedAmount + "U, square " + squareProgrammedAmount + "U, duration " + squareProgrammedDuration + " minutes";
 
             } else {
@@ -146,25 +146,25 @@ public class PumpHistoryBolus extends RealmObject implements PumpHistoryInterfac
 
             } else if (squareDelivered && squareProgrammedAmount != squareDeliveredAmount) {
                 treatment.setEnteredinsulin(String.valueOf(normalDeliveredAmount + squareDeliveredAmount));
-                treatment.setDuration(squareDeliveredDuration);
+                treatment.setDuration((float) squareDeliveredDuration);
                 treatment.setInsulin((float) normalDeliveredAmount);
                 int splitNow = (int) (normalDeliveredAmount * (100 / (normalDeliveredAmount + squareDeliveredAmount)));
                 int splitExt = 100 - splitNow;
                 treatment.setSplitNow(String.valueOf(splitNow));
                 treatment.setSplitExt(String.valueOf(splitExt));
-                treatment.setRelative(2);
+                treatment.setRelative((float) 2);
                 notes += " * ended before expected duration, square delivered " + squareDeliveredAmount + "U in " + squareDeliveredDuration + " minutes";
                 uploadItem.update();
             }
 
             if (estimate) {
                 treatment.setEventType("Meal Bolus");
-                treatment.setCarbs((int) carbInput);
+                treatment.setCarbs((float) ((int) carbInput));
                 if (!notes.equals("")) notes += "  ";
                 notes += "WIZ:"
                         + " carb " + (int) carbInput + "G : " + foodEstimate + "U"
                         + ", target " + lowBgTarget + "-" + highBgTarget + " : " + correctionEstimate + "U"
-                        + ", iob " + iob + " : " + iobAdjustment + "U"
+                        + ", iob " + iob + " : " + (iobAdjustment > 0 ? "-" : "") + iobAdjustment + "U"
                         + " (ratio " + (int) carbRatio + "/u, isf " + isf + "/u)";
             }
 

--- a/app/src/main/java/info/nightscout/android/model/store/DataStore.java
+++ b/app/src/main/java/info/nightscout/android/model/store/DataStore.java
@@ -50,6 +50,9 @@ public class DataStore extends RealmObject {
     private long sysPollOldSgvRetry;
     private boolean sysEnableWait500ms;
 
+    private boolean dbgEnableExtendedErrors;
+    private boolean dbgEnableUploadErrors;
+
     private boolean nsEnableTreatments;
     private boolean nsEnableHistorySync;
     private boolean nsEnableFingerBG;
@@ -352,6 +355,22 @@ public class DataStore extends RealmObject {
 
     public void setSysEnableWait500ms(boolean sysEnableWait500ms) {
         this.sysEnableWait500ms = sysEnableWait500ms;
+    }
+
+    public boolean isDbgEnableExtendedErrors() {
+        return dbgEnableExtendedErrors;
+    }
+
+    public void setDbgEnableExtendedErrors(boolean dbgEnableExtendedErrors) {
+        this.dbgEnableExtendedErrors = dbgEnableExtendedErrors;
+    }
+
+    public boolean isDbgEnableUploadErrors() {
+        return dbgEnableUploadErrors;
+    }
+
+    public void setDbgEnableUploadErrors(boolean dbgEnableUploadErrors) {
+        this.dbgEnableUploadErrors = dbgEnableUploadErrors;
     }
 
     public boolean isNsEnableTreatments() {

--- a/app/src/main/java/info/nightscout/android/upload/nightscout/NightscoutUploadService.java
+++ b/app/src/main/java/info/nightscout/android/upload/nightscout/NightscoutUploadService.java
@@ -106,13 +106,17 @@ public class NightscoutUploadService extends Service {
                                 }
                             });
 
-                        } else userLogMessage(ICON_WARN + "Uploading to nightscout was unsuccessful");
+                        } else {
+                            if (prefs.getBoolean("dbgEnableUploadErrors", true))
+                                userLogMessage(ICON_WARN + "Uploading to nightscout was unsuccessful");
+                        }
 
                         Log.i(TAG, String.format("Finished upload of %s record using a REST API in %s ms", records.size(), System.currentTimeMillis() - start));
                     }
                 } catch (Exception e) {
-                    userLogMessage(ICON_WARN + "Error uploading: " + e.getMessage());
                     Log.e(TAG, "ERROR uploading data!!!!!", e);
+                    if (prefs.getBoolean("dbgEnableUploadErrors", true))
+                        userLogMessage(ICON_WARN + "Error uploading: " + e.getMessage());
                 }
 
             } else {

--- a/app/src/main/java/info/nightscout/api/TreatmentsEndpoints.java
+++ b/app/src/main/java/info/nightscout/api/TreatmentsEndpoints.java
@@ -72,22 +72,22 @@ public interface TreatmentsEndpoints {
         Float insulin;
 
         @SerializedName("duration")
-        Integer duration;
+        Float duration;
 
         @SerializedName("absolute")
         Float absolute;
 
         @SerializedName("percent")
-        Integer percent;
+        Float percent;
 
         @SerializedName("relative")
-        Integer relative;
+        Float relative;
 
         @SerializedName("preBolus")
         Float preBolus;
 
         @SerializedName("carbs")
-        Integer carbs;
+        Float carbs;
 
         @SerializedName("glucose")
         BigDecimal glucose;
@@ -212,11 +212,11 @@ public interface TreatmentsEndpoints {
             this.insulin = insulin;
         }
 
-        public Integer getDuration() {
+        public Float getDuration() {
             return duration;
         }
 
-        public void setDuration(Integer duration) {
+        public void setDuration(Float duration) {
             this.duration = duration;
         }
 
@@ -228,19 +228,19 @@ public interface TreatmentsEndpoints {
             this.absolute = absolute;
         }
 
-        public Integer getPercent() {
+        public Float getPercent() {
             return percent;
         }
 
-        public void setPercent(Integer percent) {
+        public void setPercent(Float percent) {
             this.percent = percent;
         }
 
-        public Integer getRelative() {
+        public Float getRelative() {
             return relative;
         }
 
-        public void setRelative(Integer relative) {
+        public void setRelative(Float relative) {
             this.relative = relative;
         }
 
@@ -252,11 +252,11 @@ public interface TreatmentsEndpoints {
             this.preBolus = preBolus;
         }
 
-        public Integer getCarbs() {
+        public Float getCarbs() {
             return carbs;
         }
 
-        public void setCarbs(Integer carbs) {
+        public void setCarbs(Float carbs) {
             this.carbs = carbs;
         }
 
@@ -298,19 +298,6 @@ public interface TreatmentsEndpoints {
     @DELETE("/api/v1/treatments/{id}")
     Call<ResponseBody> deleteID(@Path("id") String id);
 
-
-    /*
-    @DELETE("/api/v1/treatments")
-    Call<ResponseBody> deleteDateRangeNoKey(@Query("find[created_at][$gte]") String from,
-                                            @Query("find[created_at][$lte]") String to,
-                                            @Query("find[key600][$not][$exists]") String empty);
-
-    @DELETE("/api/v1/treatments")
-    Call<ResponseBody> deleteDateRangeNotTypeNoKey(@Query("find[created_at][$gte]") String from,
-                                                   @Query("find[created_at][$lte]") String to,
-                                                   @Query("find[eventType][$ne]") String type,
-                                                   @Query("find[key600][$not][$exists]") String empty);
-*/
     @Headers({
             "Accept: application/json",
             "Content-type: application/json"

--- a/app/src/main/java/info/nightscout/urchin/Urchin.java
+++ b/app/src/main/java/info/nightscout/urchin/Urchin.java
@@ -123,6 +123,7 @@ public class Urchin {
         if (historyRealm != null && !historyRealm.isClosed()) historyRealm.close();
         if (storeRealm != null && !storeRealm.isClosed()) storeRealm.close();
         if (realm != null && !realm.isClosed()) realm.close();
+        dataStore = null;
         historyRealm = null;
         storeRealm = null;
         realm = null;

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -139,13 +139,13 @@
                 <CheckBoxPreference android:title="Single Profile Group"
                     android:dependency="nsEnableProfileUpload"
                     android:key="nsEnableProfileSingle"
-                    android:defaultValue="false"
+                    android:defaultValue="true"
                     android:summary="Only use a single profile group in nightscout (note: obsolete groups will be removed)"/>
 
                 <CheckBoxPreference android:title="Offset start date"
                     android:dependency="nsEnableProfileUpload"
                     android:key="nsEnableProfileOffset"
-                    android:defaultValue="false"
+                    android:defaultValue="true"
                     android:summary="Uploaded profile will be valid from 12 months ago"/>
 
                 <ListPreference android:title="Default Pattern"
@@ -581,6 +581,18 @@
                     android:title="Logging Level"
                     android:entries="@array/levelList"
                     android:entryValues="@array/calib_types_values" />
+            </PreferenceCategory>
+            <PreferenceCategory android:title="Userlog">
+                <SwitchPreference
+                    android:defaultValue="false"
+                    android:key="dbgEnableExtendedErrors"
+                    android:summary="Detailed errors and polling data shown in the userlog"
+                    android:title="Extended Errors" />
+                <SwitchPreference
+                    android:defaultValue="true"
+                    android:key="dbgEnableUploadErrors"
+                    android:summary="Report Nightscout uploading errors in the userlog"
+                    android:title="Upload Errors" />
             </PreferenceCategory>
         </PreferenceScreen>
     </PreferenceCategory>


### PR DESCRIPTION
Fix: gson serialisation, using floats instead of ints

Add: made userlog error messages less severe and added a debug option for showing detail error messages in the userlog

Add: debug option not to show NS errors in the userlog

Tweak: increase clear timeout before cnl close, move linkkey request back to were it was (this is where it was during dev and so more a peace of mind move)

Prefs: made default pref for profiles "single profile group" and "offset start date" true as NS currently has issues with multiple profiles and start dates.