### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ cache:
 
 env:
   global:
-  - EMULATOR_API_LEVEL=14
+  - EMULATOR_API_LEVEL=15
   - ANDROID_API_LEVEL=28
   - ANDROID_BUILD_TOOLS_VERSION=28.0.3
   - ANDROID_ABI=armeabi-v7a
-  - ADB_INSTALL_TIMEOUT=5
+  - ADB_INSTALL_TIMEOUT=8
 
 android:
   components:
@@ -33,36 +33,28 @@ android:
   - sys-img-$ANDROID_ABI-android-$ANDROID_API_LEVEL
   - sys-img-$ANDROID_ABI-android-$EMULATOR_API_LEVEL
   licenses:
-  - android-sdk-license-.+
-  - android-sdk-preview-license-.+
-  - google-gdk-license-.+
+  - android-sdk-.+
+  - google-gdk-.+
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_c75769befc95_key -iv $encrypted_c75769befc95_iv
     -in keystore.jks.enc -out keystore.jks -d
   - openssl aes-256-cbc -K $encrypted_c75769befc95_key -iv $encrypted_c75769befc95_iv
     -in fabric.properties.enc -out app/fabric.properties -d
-  - mkdir "$ANDROID_HOME/licenses" || true
-  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
-  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
   - chmod +x gradlew
   - touch $HOME/.android/repositories.cfg
   - yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
   - yes | sdkmanager "platforms;android-28"
-  - yes | sdkmanager "platforms;android-14"
+  - yes | sdkmanager "platforms;android-15"
   - yes | sdkmanager "build-tools;28.0.3"
-  - yes | sdkmanager "system-images;android-14;default;armeabi-v7a"
+  - yes | sdkmanager "system-images;android-15;google_apis;armeabi-v7a"
   - sdkmanager --list
   - yes | sdkmanager --update
   - yes | sdkmanager --licenses
 
 before_script:
-  #- echo "y" | android update sdk -a --no-ui --filter android-14
-  #- echo "y" | android update sdk -a --no-ui --filter sys-img-armeabi-v7a-android-14
-  #- android list targets | grep -E '^id:' | awk -F '"' '{$1=""; print $2}' # list all targets
-  #- echo no | android create avd --force -n test -t android-14 --abi armeabi-v7a
-  - echo no | avdmanager create avd --force -n test -k "system-images;android-14;default;armeabi-v7a"
-  - emulator -avd test -no-skin -no-window &
+  - echo no | avdmanager create avd --force -n test -k "system-images;android-15;google_apis;armeabi-v7a"
+  - $ANDROID_HOME/tools/emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 


### PR DESCRIPTION
I was able to execute gradle with this config. The build itself failed, but I didn't customized it for my repo - maybe it's worth a try?

It seems with SDK 29 support for old QEMU kernel was dropped and the new one is absent in old system images (https://github.com/microg/android_packages_apps_GmsCore/issues/815).
Version 15 with google_apis was the oldest that worked for me.